### PR TITLE
Update tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is planned to include this library in a future version of the Modelica Standa
 
 [Modelica_Synchronous v0.92.1 (2016-03-11)](../../releases/tag/v0.92.1)
 
-Please note that the library is known to work with Dymola only.
+The library is supported by at least the following tools: Dymola, OpenModelica, SimulationX.
 
 ## Older Releases
 


### PR DESCRIPTION
Remove outdated number of tools supporting Modelica_Synchronous (since both OpenModelica and SimulationX 3.9 also support it).