### PR TITLE
Add Evaluate = true to backCounter and resolution for Integer BackSample

### DIFF
--- a/Modelica_Synchronous/IntegerSignals.mo
+++ b/Modelica_Synchronous/IntegerSignals.mo
@@ -515,9 +515,9 @@ Analog to the corresponding Real signal block example there exists an elementary
     block BackSample
       "Shift clock of Integer input signal backwards in time (and access the most recent value of the input at this new clock)"
       parameter Integer backCounter(min=0)=0 "Numerator of shifting formula"
-            annotation(Dialog(group="Shift first clock activation backwards in time for 'shiftCounter/resolution*interval(u)' seconds"));
+            annotation(Evaluate = true, Dialog(group="Shift first clock activation backwards in time for 'shiftCounter/resolution*interval(u)' seconds"));
       parameter Integer resolution(min=1)=1 "Denominator of shifting formula"
-            annotation(Dialog(group="Shift first clock activation backwards in time for 'shiftCounter/resolution*interval(u)' seconds"));
+            annotation(Evaluate = true, Dialog(group="Shift first clock activation backwards in time for 'shiftCounter/resolution*interval(u)' seconds"));
       parameter Integer y_start=0
         "Value of output y before the first clock tick of the input u";
 


### PR DESCRIPTION
Note that Modelica_Synchronous.IntegerSignals.Sampler.ShiftSample has Evaluate = true on its backCounter and resolution parameters. The same goes for the Real BackSample (Modelica_Synchronous.RealSignals.Sampler.BackSample) and the Boolean BackSample (Modelica_Synchronous.BooleanSignals.Sampler.BackSample).

Thus, this change would make the library more uniform.