### PR TITLE
Utilize MSL 3.2.2 noise function (closes #18)

### DIFF
--- a/Modelica_Synchronous/RealSignals.mo
+++ b/Modelica_Synchronous/RealSignals.mo
@@ -2148,72 +2148,43 @@ There is the restriction that shiftCounter/resolution &le; 1.
           extends Modelica_Synchronous.RealSignals.Interfaces.PartialNoise;
           parameter Real noiseMax=0.1 "Upper limit of noise band";
           parameter Real noiseMin=-noiseMax "Lower limit of noise band";
-          parameter Integer firstSeed[3](each min=0, each max=255) = {23,87,187}
-            "Integer[3] defining random sequence; required element range: 0..255";
+
+          parameter Integer globalSeed = 30020 "Global seed to initialize random number generator";
+          // Random number generators with exposed state
+          parameter Integer localSeed = 614657 "Local seed to initialize random number generator";
+          output Real r64(start=0) "Random number generated with Xorshift64star";
         protected
-          Integer seedState[3](start=firstSeed, each fixed=true)
-            "State of seed"                                                      annotation(HideResult=true);
-          Real noise "Noise in the range 0..1" annotation(HideResult=true);
+          discrete Integer state64[2](start=Modelica.Math.Random.Generators.Xorshift64star.initialState(localSeed, globalSeed));
+
         equation
-          (noise,seedState) =
-            Modelica_Synchronous.RealSignals.Sampler.Utilities.Internal.random(
-            previous(seedState));
-            y = u + noiseMin + (noiseMax - noiseMin)*noise;
+          (r64, state64) = Modelica.Math.Random.Generators.Xorshift64star.random(previous(state64));
+           y = u + noiseMin + (noiseMax - noiseMin)*r64;
 
           annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
                     -100},{100,100}})),
             Documentation(info="<html>
-<p>
-This block adds uniformly distributed noise
-in the range noiseMin .. noiseMax to the clocked Real input signal
-and provides the sum as clocked Real output signal.
-</p>
-
-<p>
-The Integer[3] parameter vector <b>firstSeed</b> is used to initialize the
-basic random number generator. The 3 elements of firstSeed need
-to be in the range [0, 255]. The use of the same seed vector
-will lead to the same sequence of numbers when these are computed serially.
-This is usually not desired. Therefore, for every usage of block
-<b>Noise</b> a different firstSeed should be defined.
-</p>
-
-<p>
-This noise generator is based on a function that generates
-a random real number uniformely in the semi-open range [0.0, 1.0).
-The function uses the standard Wichmann-Hill generator,
-combining three pure multiplicative congruential generators of
-modulus 30269, 30307 and 30323. Its period (how many numbers it
-generates before repeating the sequence exactly) is 6,953,607,871,644.
-While of much higher quality than the rand() function supplied by
-most C libraries, the theoretical properties are much the same
-as for a single linear congruential generator of large modulus.
-For more details, see the underlying function
-<a href=\"modelica://Modelica_Synchronous.RealSignals.Sampler.Utilities.Internal.random\">Internal.random</a>.
-</p>
-
+<p>This block adds uniformly distributed noise in the range noiseMin .. noiseMax to the clocked Real input signal and provides the sum as clocked Real output signal. </p>
+<p><b>2019-05-17 FIXME:</b> Documentation is obsolete (describes old algorithm), update! </p>
+<p>The Integer[3] parameter vector <b>firstSeed</b> is used to initialize the basic random number generator. The 3 elements of firstSeed need to be in the range [0, 255]. The use of the same seed vector will lead to the same sequence of numbers when these are computed serially. This is usually not desired. Therefore, for every usage of block <b>Noise</b> a different firstSeed should be defined. </p>
+<p>This noise generator is based on a function that generates a random real number uniformely in the semi-open range [0.0, 1.0). The function uses the standard Wichmann-Hill generator, combining three pure multiplicative congruential generators of modulus 30269, 30307 and 30323. Its period (how many numbers it generates before repeating the sequence exactly) is 6,953,607,871,644. While of much higher quality than the rand() function supplied by most C libraries, the theoretical properties are much the same as for a single linear congruential generator of large modulus. For more details, see the underlying function <a href=\"modelica://Modelica_Synchronous.RealSignals.Sampler.Utilities.Internal.random\">Internal.random</a>. </p>
 <h4>Example</h4>
-<p>
-The following
-<a href=\"Modelica_Synchronous.Examples.Elementary.RealSignals.UniformNoise\">example</a>
-samples zero signal with a periodic clock of 20 ms period, and adds
-noise in the range from -0.1 .. 0.1:<br>
-</p>
-
-
-<table border=0 cellspacing=0 cellpadding=2>
-<tr><td width=\"50\"></td>
-    <td valign=\"bottom\"><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Model.png\"></td>
-    </tr>
-<tr><td></td>
-    <td align=\"left\">model<br></td>
-   </tr>
-<tr><td></td>
-    <td valign=\"bottom\"><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Result.png\"></td>
-    </tr>
-<tr><td></td>
-    <td align=\"center\">simulation result</td>
-   </tr>
+<p><br>The following <a href=\"Modelica_Synchronous.Examples.Elementary.RealSignals.UniformNoise\">example</a> samples zero signal with a periodic clock of 20 ms period, and adds noise in the range from -0.1 .. 0.1:</p>
+<table cellspacing=\"0\" cellpadding=\"2\" border=\"0\"><tr>
+<td></td>
+<td valign=\"bottom\"><p><br><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Model.png\"/></p></td>
+</tr>
+<tr>
+<td></td>
+<td><p><br><br>model</p></td>
+</tr>
+<tr>
+<td></td>
+<td valign=\"bottom\"><p><br><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Result.png\"/></p></td>
+</tr>
+<tr>
+<td></td>
+<td><p align=\"center\"><br>simulation result</p></td>
+</tr>
 </table>
 </html>"),  Icon(graphics={
                 Polygon(

--- a/Modelica_Synchronous/RealSignals.mo
+++ b/Modelica_Synchronous/RealSignals.mo
@@ -2144,47 +2144,76 @@ There is the restriction that shiftCounter/resolution &le; 1.
 </html>"));
         end ComputationalDelay;
 
-        block UniformNoise "Add band-limited uniform noise to a clocked signal"
+        block UniformNoise "Add band-limited uniform noise using a variant of the Wichmann-Hill algorithm"
           extends Modelica_Synchronous.RealSignals.Interfaces.PartialNoise;
           parameter Real noiseMax=0.1 "Upper limit of noise band";
           parameter Real noiseMin=-noiseMax "Lower limit of noise band";
-
-          parameter Integer globalSeed = 30020 "Global seed to initialize random number generator";
-          // Random number generators with exposed state
-          parameter Integer localSeed = 614657 "Local seed to initialize random number generator";
-          output Real r64(start=0) "Random number generated with Xorshift64star";
+          parameter Integer firstSeed[3](each min=0, each max=255) = {23,87,187}
+            "Integer[3] defining random sequence; required element range: 0..255";
         protected
-          discrete Integer state64[2](start=Modelica.Math.Random.Generators.Xorshift64star.initialState(localSeed, globalSeed));
-
+          Integer seedState[3](start=firstSeed, each fixed=true)
+            "State of seed"                                                      annotation(HideResult=true);
+          Real noise "Noise in the range 0..1" annotation(HideResult=true);
         equation
-          (r64, state64) = Modelica.Math.Random.Generators.Xorshift64star.random(previous(state64));
-           y = u + noiseMin + (noiseMax - noiseMin)*r64;
+          (noise,seedState) =
+            Modelica_Synchronous.RealSignals.Sampler.Utilities.Internal.random(
+            previous(seedState));
+            y = u + noiseMin + (noiseMax - noiseMin)*noise;
 
           annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
                     -100},{100,100}})),
             Documentation(info="<html>
-<p>This block adds uniformly distributed noise in the range noiseMin .. noiseMax to the clocked Real input signal and provides the sum as clocked Real output signal. </p>
-<p><b>2019-05-17 FIXME:</b> Documentation is obsolete (describes old algorithm), update! </p>
-<p>The Integer[3] parameter vector <b>firstSeed</b> is used to initialize the basic random number generator. The 3 elements of firstSeed need to be in the range [0, 255]. The use of the same seed vector will lead to the same sequence of numbers when these are computed serially. This is usually not desired. Therefore, for every usage of block <b>Noise</b> a different firstSeed should be defined. </p>
-<p>This noise generator is based on a function that generates a random real number uniformely in the semi-open range [0.0, 1.0). The function uses the standard Wichmann-Hill generator, combining three pure multiplicative congruential generators of modulus 30269, 30307 and 30323. Its period (how many numbers it generates before repeating the sequence exactly) is 6,953,607,871,644. While of much higher quality than the rand() function supplied by most C libraries, the theoretical properties are much the same as for a single linear congruential generator of large modulus. For more details, see the underlying function <a href=\"modelica://Modelica_Synchronous.RealSignals.Sampler.Utilities.Internal.random\">Internal.random</a>. </p>
+<p>
+This block adds uniformly distributed noise
+in the range noiseMin .. noiseMax to the clocked Real input signal
+and provides the sum as clocked Real output signal.
+</p>
+
+<p>
+The Integer[3] parameter vector <b>firstSeed</b> is used to initialize the
+basic random number generator. The 3 elements of firstSeed need
+to be in the range [0, 255]. The use of the same seed vector
+will lead to the same sequence of numbers when these are computed serially.
+This is usually not desired. Therefore, for every usage of block
+<b>Noise</b> a different firstSeed should be defined.
+</p>
+
+<p>
+This noise generator is based on a function that generates
+a random real number uniformely in the semi-open range [0.0, 1.0).
+The function uses the standard Wichmann-Hill generator,
+combining three pure multiplicative congruential generators of
+modulus 30269, 30307 and 30323. Its period (how many numbers it
+generates before repeating the sequence exactly) is 6,953,607,871,644.
+While of much higher quality than the rand() function supplied by
+most C libraries, the theoretical properties are much the same
+as for a single linear congruential generator of large modulus.
+For more details, see the underlying function
+<a href=\"modelica://Modelica_Synchronous.RealSignals.Sampler.Utilities.Internal.random\">Internal.random</a>.
+</p>
+
 <h4>Example</h4>
-<p><br>The following <a href=\"Modelica_Synchronous.Examples.Elementary.RealSignals.UniformNoise\">example</a> samples zero signal with a periodic clock of 20 ms period, and adds noise in the range from -0.1 .. 0.1:</p>
-<table cellspacing=\"0\" cellpadding=\"2\" border=\"0\"><tr>
-<td></td>
-<td valign=\"bottom\"><p><br><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Model.png\"/></p></td>
-</tr>
-<tr>
-<td></td>
-<td><p><br><br>model</p></td>
-</tr>
-<tr>
-<td></td>
-<td valign=\"bottom\"><p><br><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Result.png\"/></p></td>
-</tr>
-<tr>
-<td></td>
-<td><p align=\"center\"><br>simulation result</p></td>
-</tr>
+<p>
+The following
+<a href=\"Modelica_Synchronous.Examples.Elementary.RealSignals.UniformNoise\">example</a>
+samples zero signal with a periodic clock of 20 ms period, and adds
+noise in the range from -0.1 .. 0.1:<br>
+</p>
+
+
+<table border=0 cellspacing=0 cellpadding=2>
+<tr><td width=\"50\"></td>
+    <td valign=\"bottom\"><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Model.png\"></td>
+    </tr>
+<tr><td></td>
+    <td align=\"left\">model<br></td>
+   </tr>
+<tr><td></td>
+    <td valign=\"bottom\"><img src=\"modelica://Modelica_Synchronous/Resources/Images/RealSignals/UniformNoise_Result.png\"></td>
+    </tr>
+<tr><td></td>
+    <td align=\"center\">simulation result</td>
+   </tr>
 </table>
 </html>"),  Icon(graphics={
                 Polygon(
@@ -2301,6 +2330,149 @@ There is the restriction that shiftCounter/resolution &le; 1.
                   lineColor={255,0,0},
                   textString="%noiseMin")}));
         end UniformNoise;
+
+        block UniformNoiseXorshift64star
+          "Add band-limited uniform noise based on a xorshift64* number generator"
+          extends Modelica_Synchronous.RealSignals.Interfaces.PartialNoise;
+          parameter Real noiseMax=0.1 "Upper limit of noise band";
+          parameter Real noiseMin=-noiseMax "Lower limit of noise band";
+
+          parameter Integer globalSeed = 30020 "Global seed to initialize random number generator";
+          // Random number generators with exposed state
+          parameter Integer localSeed = 614657 "Local seed to initialize random number generator";
+          output Real r64(start=0) "Random number generated with Xorshift64star";
+        protected
+          discrete Integer state64[2](start=Modelica.Math.Random.Generators.Xorshift64star.initialState(localSeed, globalSeed));
+
+        equation
+          (r64, state64) = Modelica.Math.Random.Generators.Xorshift64star.random(previous(state64));
+           y = u + noiseMin + (noiseMax - noiseMin)*r64;
+
+          annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
+                    -100},{100,100}})),
+            Documentation(info="<html>
+<p>This block adds uniformly distributed noise in the range noiseMin .. noiseMax to the clocked Real input signal and provides the sum as clocked Real output signal. </p>
+<p>
+It is based on the xorshift64* algorithm.
+For more details, see the documentation to
+<a href=\"modelica://Modelica.Math.Random.Generators.Xorshift64star\">Xorshift64star</a>.
+</p>
+<p><b>2019-05-20 TODO:</b> Add an example which exercises this block.</p>
+</html>"),  Icon(graphics={
+                Polygon(
+                  points={{-81,90},{-89,68},{-73,68},{-81,90}},
+                  lineColor={192,192,192},
+                  fillColor={192,192,192},
+                  fillPattern=FillPattern.Solid),
+                Text(
+                  extent={{-74,92},{90,68}},
+                  lineColor={255,0,0},
+                  textString="%noiseMax"),
+                Line(points={{-81,78},{-81,-90}}, color={192,192,192}),
+                Line(points={{-89,62},{85,62}}, color={255,0,0}),
+                Line(points={{-81,-17},{-67,-17},{-67,-1},{-59,-1},{-59,-49},{
+                      -51,-49},{-51,-27},{-43,-27},{-43,57},{-35,57},{-35,25}},
+                                                                       color={0,0,
+                      127},
+                  pattern=LinePattern.Dot),
+                Line(points={{-35,25},{-35,-35},{-25,-35},{-25,-17},{-15,-17},{
+                      -15,-45},{-5,-45},{-5,37},{1,37},{1,51},{7,51},{7,-5},{17,
+                      -5},{17,7},{23,7},{23,-23},{33,-23},{33,49},{43,49},{43,
+                      15},{51,15},{51,-51},{61,-51}},
+                    color={0,0,127},
+                  pattern=LinePattern.Dot),
+                Line(points={{-90,-23},{82,-23}}, color={192,192,192}),
+                Polygon(
+                  points={{91,-22},{69,-14},{69,-30},{91,-22}},
+                  lineColor={192,192,192},
+                  fillColor={192,192,192},
+                  fillPattern=FillPattern.Solid),
+                Line(points={{-90,-54},{84,-54}}, color={255,0,0}),
+                Ellipse(
+                  extent={{-84,-13},{-78,-19}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-70,3},{-64,-3}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-62,-47},{-56,-53}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-54,-23},{-48,-29}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-46,59},{-40,53}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-38,-33},{-32,-39}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-28,-15},{-22,-21}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-18,-41},{-12,-47}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-8,39},{-2,33}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{-2,53},{4,47}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{4,-1},{10,-7}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{14,9},{20,3}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{20,-19},{26,-25}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{30,53},{36,47}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{40,19},{46,13}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Ellipse(
+                  extent={{48,-47},{54,-53}},
+                  lineColor={0,0,127},
+                  fillColor={0,0,127},
+                  fillPattern=FillPattern.Solid),
+                Text(
+                  extent={{-80,-62},{98,-84}},
+                  lineColor={255,0,0},
+                  textString="%noiseMin")}));
+        end UniformNoiseXorshift64star;
 
         model Quantization "DAC quantization effects"
         extends Modelica_Synchronous.RealSignals.Interfaces.PartialClockedSISO;


### PR DESCRIPTION
Still need to do updates to the documentation before merging the PR. 

Apart from that, this should close #18.

@tbeu Don't know much about performance and quality differences between the various algorithms. In general I prefer performance over quality for this application. Of course it would also be nice if the user could choose different distributions. Unfortunately, one cannot simply reuse the blocks in `Modelica.Blocks.Noise`, because they use non-clocked sampled when-clauses etc. If one wants this functionality also for clocked blocks one would need to clone those blocks and make some modifications.