### PR TITLE
Backport of MSL 4 fix

### DIFF
--- a/Modelica_Synchronous/ClockSignals.mo
+++ b/Modelica_Synchronous/ClockSignals.mo
@@ -285,8 +285,7 @@ For an example, see
           annotation (Placement(transformation(extent = {{-76,-54},{-64,-66}})));
 
       algorithm
-        assert(
-          not (trigger_interval == 0),
+        assert(trigger_interval > 0 or trigger_interval < 0,
           "The rotational-interval of rotational clocks must be non-zero.");
 
       equation

--- a/Modelica_Synchronous/package.mo
+++ b/Modelica_Synchronous/package.mo
@@ -6,9 +6,9 @@ extends Modelica.Icons.Package;
   annotation (preferredView="info",
   uses(Modelica(version="3.2.3"), ModelicaServices(version="3.2.3")),
     version="0.93.0",
-    versionBuild=1,
-    versionDate="2019-04-10",
-    dateModified = "2019-04-10 10:50:00Z",
+    versionBuild=2,
+    versionDate="2020-02-26",
+    dateModified = "2020-02-26 10:50:00Z",
     revisionId="$Id::                                       $",
   Documentation(info="<html>
 <p>


### PR DESCRIPTION
Backport of:
https://github.com/bernhard-thiele/ModelicaStandardLibrary/commit/9071714dca977dee494bf771ecdf357a697cac90

To remove incorrect Modelica code.

And bump versionbuild etc., I know that Modelica.Clocked shall ideally be used, but for people using MSL 3.2.3 this is a good change. We should likely add a statement about the future in the readme-file.